### PR TITLE
修复手指直接按在父布局上时，页面跳动的问题

### DIFF
--- a/app/src/main/java/com/ywg/stickylayout/widget/SlidingLayout.java
+++ b/app/src/main/java/com/ywg/stickylayout/widget/SlidingLayout.java
@@ -314,6 +314,7 @@ public class SlidingLayout extends FrameLayout {
         switch (event.getAction()){
             case MotionEvent.ACTION_DOWN:
 //                Log.i("onTouchEvent", "down");
+                mLastMotionY = getMotionEventY(event, mActivePointerId);
                 break;
             case MotionEvent.ACTION_MOVE:
                 float delta = 0.0f;


### PR DESCRIPTION
修复 ACTION_DOWN 直接分发给 ReboundLayout时，出现的页面闪动的问题。